### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,8 @@
     "node-cron": "^3.0.3",
     "undici": "^6.19.8",
     "undici-proxy": "^0.3.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
Potential fix for [https://github.com/MrSaerus/ym2lidarr/security/code-scanning/4](https://github.com/MrSaerus/ym2lidarr/security/code-scanning/4)

The best way to fix this problem is to add rate limiting specifically to the `/api/settings/test/yandex` endpoint. The most common solution in an Express environment is to use the `express-rate-limit` middleware package. To implement this fix:

- Import `express-rate-limit` at the top of the file.
- Define a rate limiter, such as allowing 5 requests per minute from each IP address for this sensitive route.
- Apply the rate limiter as middleware to the affected route (the `.post('/test/yandex', ...)`) by passing it as an argument before the route handler.

All edits must be inside `apps/api/src/routes/settings.ts`. You'll need to add the import, define the rate limiter, and update the route invocation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
