### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/apps/pyproxy/main.py
+++ b/apps/pyproxy/main.py
@@ -2,10 +2,12 @@
 import asyncio
 from typing import List, Optional, Dict, Any
 from fastapi import FastAPI, Body
+import logging
 from pydantic import BaseModel
 from yandex_music import ClientAsync
 
 app = FastAPI(title="YA PyProxy")
+logger = logging.getLogger("pyproxy")
 
 # ====== Schemas ======
 class ArtistOut(BaseModel):
@@ -76,7 +78,8 @@ async def verify(token: str = Body(..., embed=True)):
 
         return {"ok": True, "uid": uid, "login": login}
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        logger.exception("Exception occurred during token verification")
+        return {"ok": False, "error": "An internal error occurred"}
 
 @app.post("/likes", response_model=LikesResponse)
 async def likes(token: str = Body(..., embed=True)):


### PR DESCRIPTION
Potential fix for [https://github.com/MrSaerus/ym2lidarr/security/code-scanning/2](https://github.com/MrSaerus/ym2lidarr/security/code-scanning/2)

To fix this problem, we should ensure that users receive only a generic error message rather than the raw exception string. Internally, we should log the full exception details (including any stack traces) for debugging purposes, but not send them to the client. FastAPI does not include a logger by default, but Python’s built-in `logging` library is suitable and widely used, and we can use it without adding extra dependencies. The change needs to be made in the `/verify` endpoint handler, specifically the block catching exceptions on lines 78–79. Add a logging call that records the exception and stack trace, then replace the error value sent to the client with a fixed, generic string such as `"An internal error occurred"`.

**Steps:**
- Add `import logging` near the top.
- Create a module-level logger.
- In the `except Exception as e:` block of the `/verify` endpoint, log the exception (with stack trace) using `logger.exception`.
- Return a generic error message to the client instead of `str(e)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
